### PR TITLE
Use Solana devnet in sign API

### DIFF
--- a/syos-solstarter/src/pages/api/sign/create.ts
+++ b/syos-solstarter/src/pages/api/sign/create.ts
@@ -1,11 +1,11 @@
 import {
+  clusterApiUrl,
   Connection,
   PublicKey,
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
 import { NextApiRequest, NextApiResponse } from "next";
-import { NETWORK } from "@utils/endpoints";
 import { MEMO_PROGRAM_ID, NONCE } from "@utils/globals";
 
 export type SignCreateData = {
@@ -19,7 +19,7 @@ export default async function handler(
   if (req.method === "POST") {
     const { publicKeyStr } = req.body;
 
-    const connection = new Connection(NETWORK);
+    const connection = new Connection(clusterApiUrl("devnet"));
     const publicKey = new PublicKey(publicKeyStr);
 
     // Ideally this would be stored in a DB for each publicKey

--- a/syos-solstarter/src/pages/index.tsx
+++ b/syos-solstarter/src/pages/index.tsx
@@ -165,13 +165,3 @@ const Home: NextPage = () => {
 };
 
 export default Home;
-import LivePriceDisplay from "../components/LivePriceDisplay";
-
-export default function Home() {
-  return (
-    <div className="flex flex-col items-center justify-center">
-      <LivePriceDisplay />
-      {/* Existing wallet logic below */}
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- switch `/api/sign/create` to connect with Solana devnet by default
- remove endpoint constant import
- fix duplicate default export in index page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0eaeed908323a212dd1c3fb9a819