### PR TITLE
Use Solana devnet & fix export

### DIFF
--- a/syos-solstarter/src/pages/api/sign/create.ts
+++ b/syos-solstarter/src/pages/api/sign/create.ts
@@ -1,11 +1,11 @@
 import {
+  clusterApiUrl,
   Connection,
   PublicKey,
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
 import { NextApiRequest, NextApiResponse } from "next";
-import { NETWORK } from "@utils/endpoints";
 import { MEMO_PROGRAM_ID, NONCE } from "@utils/globals";
 
 export type SignCreateData = {
@@ -19,7 +19,8 @@ export default async function handler(
   if (req.method === "POST") {
     const { publicKeyStr } = req.body;
 
-    const connection = new Connection(NETWORK);
+    // Connect to devnet without needing an API key
+    const connection = new Connection(clusterApiUrl("devnet"));
     const publicKey = new PublicKey(publicKeyStr);
 
     // Ideally this would be stored in a DB for each publicKey

--- a/syos-solstarter/src/pages/index.tsx
+++ b/syos-solstarter/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import type { NextPage } from "next";
 import Head from "next/head";
 import React from "react";
 import { Header } from "@components/layout/header";
@@ -17,8 +16,9 @@ import { fetcher, useDataFetch } from "@utils/use-data-fetch";
 import { toast } from "react-hot-toast";
 import { Modal } from "@components/layout/modal";
 import { Footer } from "@components/layout/footer";
+import LivePriceDisplay from "../components/LivePriceDisplay";
 
-const Home: NextPage = () => {
+export default function Home() {
   const { publicKey, signTransaction, connected } = useWallet();
 
   const { data } = useDataFetch<TwitterResponse>(
@@ -134,6 +134,9 @@ const Home: NextPage = () => {
       <DrawerContainer>
         <PageContainer>
           <Header twitterHandle={twitterHandle} />
+          <div className="flex flex-col items-center justify-center">
+            <LivePriceDisplay />
+          </div>
           <HomeContent />
           <Footer />
         </PageContainer>
@@ -162,16 +165,5 @@ const Home: NextPage = () => {
       />
     </>
   );
-};
-
-export default Home;
-import LivePriceDisplay from "../components/LivePriceDisplay";
-
-export default function Home() {
-  return (
-    <div className="flex flex-col items-center justify-center">
-      <LivePriceDisplay />
-      {/* Existing wallet logic below */}
-    </div>
-  );
 }
+


### PR DESCRIPTION
## Summary
- connect to Solana devnet when creating sign transactions
- add LivePriceDisplay component to the homepage
- fix duplicate export in index page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0eaeed908323a212dd1c3fb9a819