### PR TITLE
Configure Solana RPC via env variable

### DIFF
--- a/syos-solstarter/.env.local
+++ b/syos-solstarter/.env.local
@@ -1,0 +1,2 @@
+HELIUS_API_KEY=
+NEXT_PUBLIC_SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}

--- a/syos-solstarter/README.md
+++ b/syos-solstarter/README.md
@@ -63,10 +63,11 @@ https://user-images.githubusercontent.com/38172/212745502-628238cd-311c-436c-b66
 
 1. Get an API key from [Helius](https://helius.xyz/). We'll need this to be able to fetch wallet details.
 2. Run `npx create-next-app -e https://github.com/aeminium-labs/nextjs-solana-starter-kit` to get this template into your local environment (can also click on the "Use this template" button or just fork this repository)
-3. Add a `.env.local` file with your Helius API key
+3. Add a `.env.local` file with your Helius API key and RPC URL
 
 ```
 HELIUS_API_KEY=<your key>
+NEXT_PUBLIC_SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}
 ```
 
 4. Run `npm run dev` to start dev server

--- a/syos-solstarter/src/pages/api/items/[address].ts
+++ b/syos-solstarter/src/pages/api/items/[address].ts
@@ -1,4 +1,3 @@
-import { NETWORK } from "@utils/endpoints";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { ItemData } from "@components/home/item";

--- a/syos-solstarter/src/pages/api/sign/create.ts
+++ b/syos-solstarter/src/pages/api/sign/create.ts
@@ -1,12 +1,11 @@
 import {
-  clusterApiUrl,
-  Connection,
   PublicKey,
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
 import { NextApiRequest, NextApiResponse } from "next";
 import { MEMO_PROGRAM_ID, NONCE } from "@utils/globals";
+import { solanaConnection } from "@utils/solanaConnection";
 
 export type SignCreateData = {
   tx: string;
@@ -19,7 +18,7 @@ export default async function handler(
   if (req.method === "POST") {
     const { publicKeyStr } = req.body;
 
-    const connection = new Connection(clusterApiUrl("devnet"));
+    const connection = solanaConnection;
     const publicKey = new PublicKey(publicKeyStr);
 
     // Ideally this would be stored in a DB for each publicKey

--- a/syos-solstarter/src/pages/api/twitter/[key].ts
+++ b/syos-solstarter/src/pages/api/twitter/[key].ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getHandleAndRegistryKey } from "@solana/spl-name-service";
-import { PublicKey, Connection } from "@solana/web3.js";
-import { NETWORK } from "@utils/endpoints";
+import { PublicKey } from "@solana/web3.js";
+import { solanaConnection } from "@utils/solanaConnection";
 
 export type TwitterResponse = { handle: string | undefined };
 export default async function handler(
@@ -10,7 +10,7 @@ export default async function handler(
 ) {
   const { key } = req.query;
 
-  const connection = new Connection(NETWORK);
+  const connection = solanaConnection;
   if (key && key.length > 0 && typeof key === "string") {
     try {
       const [twitterHandle] = await getHandleAndRegistryKey(

--- a/syos-solstarter/src/pages/api/tx/confirm.ts
+++ b/syos-solstarter/src/pages/api/tx/confirm.ts
@@ -1,6 +1,5 @@
-import { Connection } from "@solana/web3.js";
 import { NextApiRequest, NextApiResponse } from "next";
-import { NETWORK } from "@utils/endpoints";
+import { solanaConnection } from "@utils/solanaConnection";
 
 export type TxConfirmData = {
   confirmed: boolean;
@@ -14,7 +13,7 @@ export default async function handler(
   if (req.method === "POST") {
     const { txSignature } = req.body;
 
-    const connection = new Connection(NETWORK);
+    const connection = solanaConnection;
 
     const latestBlockhash = await connection.getLatestBlockhash("finalized");
     try {

--- a/syos-solstarter/src/pages/api/tx/create.ts
+++ b/syos-solstarter/src/pages/api/tx/create.ts
@@ -1,12 +1,11 @@
 import {
-  Connection,
   LAMPORTS_PER_SOL,
   PublicKey,
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
 import { NextApiRequest, NextApiResponse } from "next";
-import { NETWORK } from "@utils/endpoints";
+import { solanaConnection } from "@utils/solanaConnection";
 import {
   createAssociatedTokenAccountInstruction,
   createTransferCheckedInstruction,
@@ -41,7 +40,7 @@ export default async function handler(
       tokenAddress = DEFAULT_TOKEN,
     } = req.body as Input;
 
-    const connection = new Connection(NETWORK);
+    const connection = solanaConnection;
 
     const payer = new PublicKey(payerAddress);
     const receiver = new PublicKey(receiverAddress);

--- a/syos-solstarter/src/pages/api/tx/send.ts
+++ b/syos-solstarter/src/pages/api/tx/send.ts
@@ -1,6 +1,6 @@
-import { Connection, Transaction } from "@solana/web3.js";
+import { Transaction } from "@solana/web3.js";
 import { NextApiRequest, NextApiResponse } from "next";
-import { NETWORK } from "@utils/endpoints";
+import { solanaConnection } from "@utils/solanaConnection";
 
 export type TxSendData = {
   txSignature: string;
@@ -13,7 +13,7 @@ export default async function handler(
   if (req.method === "POST") {
     const { signedTx } = req.body;
 
-    const connection = new Connection(NETWORK);
+    const connection = solanaConnection;
     const tx = Transaction.from(Buffer.from(signedTx, "base64"));
 
     const txSignature = await connection.sendRawTransaction(tx.serialize());

--- a/syos-solstarter/src/utils/endpoints.ts
+++ b/syos-solstarter/src/utils/endpoints.ts
@@ -9,5 +9,6 @@ export const METAPLEX = "https://api.metaplex.solana.com";
 export const SERUM = "https://solana-api.projectserum.com";
 export const HELIUS = `https://rpc.helius.xyz/?api-key=${process.env.HELIUS_API_KEY}`;
 
-// You can use any of the other enpoints here
-export const NETWORK = HELIUS;
+// Use custom RPC if provided, otherwise fall back to Helius
+export const NETWORK =
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL || HELIUS;

--- a/syos-solstarter/src/utils/solanaConnection.ts
+++ b/syos-solstarter/src/utils/solanaConnection.ts
@@ -1,0 +1,6 @@
+import { Connection } from "@solana/web3.js";
+
+export const RPC_URL =
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL || "https://api.devnet.solana.com";
+
+export const solanaConnection = new Connection(RPC_URL, "confirmed");


### PR DESCRIPTION
## Summary
- add `.env.local` with RPC url template
- expose solanaConnection helper
- read custom RPC endpoint from env
- use the helper for all API routes
- document env setup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b1f4e94148323a161af439a679425